### PR TITLE
Fix time encoding

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,5 +11,5 @@ group :test do
   gem "minitest"
   gem "mocha"
   gem "timecop"
-  gem "base32"
+  gem "base32-crockford"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,7 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    base32 (0.3.2)
+    base32-crockford (0.1.0)
     byebug (9.0.5)
     coderay (1.1.1)
     metaclass (0.0.4)
@@ -31,7 +31,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  base32
+  base32-crockford
   minitest
   mocha
   pry-byebug
@@ -40,4 +40,4 @@ DEPENDENCIES
   ulid!
 
 BUNDLED WITH
-   1.12.5
+   1.16.0

--- a/lib/ext/time.rb
+++ b/lib/ext/time.rb
@@ -1,5 +1,0 @@
-class Time
-  def self.now_100usec
-    (now.to_f * 10_000).to_i
-  end
-end

--- a/lib/ulid/generator.rb
+++ b/lib/ulid/generator.rb
@@ -10,28 +10,39 @@ module ULID
 
     MASK = 0x1f
 
-    def generate
-      input = octo_word
-      (1..ENCODED_LENGTH).to_a.reduce("") do |s, n|
-        shift = BIT_LENGTH - BITS_PER_B32_CHAR * n
-        s + ENCODING[(input >> shift) & MASK]
-      end
+    def generate(time = Time.now)
+      input = octo_word(time)
+
+      encode(input, ENCODED_LENGTH)
     end
 
-    def generate_bytes
-      time_48bit + random_bytes
+    def generate_bytes(time = Time.now)
+      time_48bit(time) + random_bytes
     end
 
     private
 
-    def octo_word
-      (hi, lo) = generate_bytes.unpack("Q>Q>")
+    def encode(n, length)
+      e = "0" * length
+      i = length - 1
+
+      while n > 0
+        e[i] = ENCODING[n & MASK]
+        n >>= 5
+        i -= 1
+      end
+
+      e
+    end
+
+    def octo_word(time = Time.now)
+      (hi, lo) = generate_bytes(time).unpack("Q>Q>")
       (hi << 64) | lo
     end
 
-    def time_48bit
-      hundred_micro_time = Time.now_100usec
-      [hundred_micro_time].pack("Q>")[2..-1]
+    def time_48bit(time = Time.now)
+      time_ms = (time.to_f * 1000).to_i
+      [time_ms].pack("Q>")[2..-1]
     end
 
     def random_bytes


### PR DESCRIPTION
Hi. First of all, thank you for writing this library! ULID is exactly what I need right now.

This PR fixes the encoding so that it's compatible with the spec described in the JavaScript implementation's README: https://github.com/alizain/ulid#specification. The main difference is that the ULID spec says that time is encoded as a 48-bit integer unix timestamp with millisecond precision. The implementation here was using 100ns precision (which is what UUIDv1 and UUIDv2 use). I think that's the same issue that's reported in #7, so I marked this commit as fixing that issue.

After fixing that, I was still having some issues with the Base32 encoding. I rewrote the base32 encoding, which fixed the encoding issue, and I measured a 14% performance increase for `ULID.generate` with [Benchmark](http://ruby-doc.org/stdlib-2.4.0/libdoc/benchmark/rdoc/Benchmark.html).

I hope you don't mind that I removed the monkey-patch on the `Time` class. It was publicly available to any project that uses this library. I'm assuming that that wasn't your intention. The conversion from time to milliseconds is only done in one place now, so it doesn't seem necessary anyway.