### PR TITLE
Ruby 2.5+ does not need sysrandom

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,6 @@ PATH
   remote: .
   specs:
     ulid (1.0.0)
-      sysrandom (>= 1.0.0, < 2.0)
 
 GEM
   remote: https://rubygems.org/
@@ -37,7 +36,6 @@ GEM
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.0, >= 1.0.1)
     ruby-progressbar (1.8.3)
-    sysrandom (1.0.5)
     timecop (0.9.1)
     unicode-display_width (1.3.0)
 
@@ -55,4 +53,4 @@ DEPENDENCIES
   ulid!
 
 BUNDLED WITH
-   1.16.0
+   1.17.3

--- a/lib/ulid/generator.rb
+++ b/lib/ulid/generator.rb
@@ -1,4 +1,8 @@
-require 'securerandom'
+if RUBY_VERSION >= '2.5'
+  require 'securerandom'
+else
+  require 'sysrandom/securerandom'
+end
 
 module ULID
   module Generator

--- a/lib/ulid/generator.rb
+++ b/lib/ulid/generator.rb
@@ -1,4 +1,4 @@
-require 'sysrandom'
+require 'securerandom'
 
 module ULID
   module Generator
@@ -46,7 +46,7 @@ module ULID
     end
 
     def random_bytes
-      Sysrandom.random_bytes(RANDOM_BYTES)
+      SecureRandom.random_bytes(RANDOM_BYTES)
     end
   end
 end

--- a/spec/lib/ulid_spec.rb
+++ b/spec/lib/ulid_spec.rb
@@ -49,7 +49,7 @@ describe ULID do
     end
 
     it 'encodes the remaining 80 bits as random' do
-      random_bytes = Sysrandom.random_bytes(ULID::Generator::RANDOM_BYTES)
+      random_bytes = SecureRandom.random_bytes(ULID::Generator::RANDOM_BYTES)
       ULID.stubs(:random_bytes).returns(random_bytes)
       bytes = ULID.generate_bytes
       assert bytes[6..-1] == random_bytes

--- a/ulid.gemspec
+++ b/ulid.gemspec
@@ -16,4 +16,6 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
+
+  spec.required_ruby_version = '>= 2.5.0'
 end

--- a/ulid.gemspec
+++ b/ulid.gemspec
@@ -17,5 +17,5 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = '>= 2.5.0'
+  spec.add_dependency 'sysrandom', '>= 1.0.0', '< 2.0' unless RUBY_VERSION >= '2.5'
 end

--- a/ulid.gemspec
+++ b/ulid.gemspec
@@ -17,5 +17,5 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'sysrandom', '>= 1.0.0', '< 2.0' unless RUBY_VERSION >= '2.5'
+  spec.add_dependency 'sysrandom', '>= 1.0.0', '< 2.0' if RUBY_VERSION < '2.5'
 end

--- a/ulid.gemspec
+++ b/ulid.gemspec
@@ -16,6 +16,4 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
-
-  spec.add_dependency 'sysrandom', '>= 1.0.0', '< 2.0'
 end


### PR DESCRIPTION
Ulid depends on _archived_ [sysrandom](https://github.com/cryptosphere/sysrandom) gem.
I think this is becase Ruby's SecureRandom [did not try /dev/urandom first](https://bugs.ruby-lang.org/issues/9569).  But this has been changed in Ruby 2.5. Ruby 2.5+'s SecureRandom does [try /dev/urandom first](https://bugs.ruby-lang.org/projects/ruby-trunk/repository/trunk/revisions/57384).
So in Ruby 2.5+, ulid does not need to depend on sysrandom.