### PR TITLE
Remove circular require warning

### DIFF
--- a/lib/ulid.rb
+++ b/lib/ulid.rb
@@ -1,4 +1,4 @@
-Dir.glob(File.join(File.dirname(__FILE__), '/**/*.rb')).sort.each { |f| require f }
+Dir.glob(File.join(__dir__, 'ulid/**/*.rb')).sort.each { |f| require f }
 
 module ULID
   extend Generator


### PR DESCRIPTION
Problem
===



This gem displays circular require warning on loading the gem if `ruby -w` is specified.


```console
$ ruby -w -rulid -e ''
/home/pocke/.rbenv/versions/trunk/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:54: warning: /home/pocke/.rbenv/versions/trunk/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:54: warning: loading in progress, circular require considered harmful - /home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/ulid-1.1.0/lib/ulid.rb
	from /home/pocke/.rbenv/versions/trunk/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:34:in  `require'
	from /home/pocke/.rbenv/versions/trunk/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:130:in  `rescue in require'
	from /home/pocke/.rbenv/versions/trunk/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:130:in  `require'
	from /home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/ulid-1.1.0/lib/ulid.rb:1:in  `<top (required)>'
	from /home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/ulid-1.1.0/lib/ulid.rb:1:in  `each'
	from /home/pocke/.rbenv/versions/trunk/lib/ruby/gems/2.7.0/gems/ulid-1.1.0/lib/ulid.rb:1:in  `block in <top (required)>'
	from /home/pocke/.rbenv/versions/trunk/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:54:in  `require'
	from /home/pocke/.rbenv/versions/trunk/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:54:in  `require'
```

Because `lib/ulid.rb` requires itself.


Solution
===


Specify `lib/ulid/**/*.rb` for glob to require to avoid requiring itself.


