### PR TITLE
Add post_install_message to install sysrandom gem

### DIFF
--- a/ulid.gemspec
+++ b/ulid.gemspec
@@ -17,5 +17,8 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'sysrandom', '>= 1.0.0', '< 2.0' if RUBY_VERSION < '2.5'
+  spec.post_install_message = %q[
+ulid gem needs to install sysrandom gem if you use Ruby 2.4 or older.
+Execute `gem install sysrandom` or add `gem "sysrandom"` to Gemfile.
+]
 end


### PR DESCRIPTION
# Problem

The dependency of sysrandom gem has been removed by https://github.com/rafaelsales/ulid/pull/14 for Ruby 2.5+, but it does not work expectedly.

Condition with `RUBY_VERSION` is meaningless in gemspec.  Because gemspec is evaluated on `rake release`. Not `gem install ulid`. So, if you execute `rake release` with Ruby 2.5, the gem does not have the dependency on sysrandom. If you use Ruby 2.4 instead, it will have the dependency.

Now the gem does not have any dependencies. https://rubygems.org/gems/ulid
So sysrandom gem is not installed anytime.


```bash
# With ruby 2.4
$ ruby -v
ruby 2.4.3p205 (2017-12-14 revision 61247) [x86_64-linux]

# `gem install` does not install sysrandom
$ gem install ulid
Successfully installed ulid-1.1.0
1 gem installed

# `bundle install` also does not install it.
$ echo 'source "https://rubygems.org"; gem "ulid"' > Gemfile
$ bundle install
Fetching gem metadata from https://rubygems.org/..
Using bundler 1.17.3
Fetching ulid 1.1.0
Installing ulid 1.1.0
Bundle complete! 1 Gemfile dependency, 2 gems now installed.
Use `bundle info [gemname]` to see where a bundled gem is installed.
```

# Solution



Use `post_install_message` instead of the condition.

We can confirm the message with `gem install --local`


```bash
$ bundle exec rake build
ulid 1.1.0 built to pkg/ulid-1.1.0.gem.

$ gem install --local pkg/ulid-1.1.0.gem

ulid gem needs to install sysrandom gem if you use Ruby 2.4 or older.
Execute `gem install sysrandom` or add `gem "sysrandom"` to Gemfile.
Successfully installed ulid-1.1.0
1 gem installed
```