### PR TITLE
Remove Timecop gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,5 +12,4 @@ group :test do
   gem 'base32-crockford'
   gem 'minitest'
   gem 'mocha'
-  gem 'timecop'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ulid (1.0.0)
+    ulid (1.1.0)
 
 GEM
   remote: https://rubygems.org/
@@ -36,7 +36,6 @@ GEM
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.0, >= 1.0.1)
     ruby-progressbar (1.8.3)
-    timecop (0.9.1)
     unicode-display_width (1.3.0)
 
 PLATFORMS
@@ -49,7 +48,6 @@ DEPENDENCIES
   pry-byebug
   rake
   rubocop
-  timecop
   ulid!
 
 BUNDLED WITH

--- a/spec/lib/ulid_spec.rb
+++ b/spec/lib/ulid_spec.rb
@@ -1,5 +1,4 @@
 require 'spec_helper'
-require 'timecop'
 require 'base32/crockford'
 
 describe ULID do
@@ -12,11 +11,9 @@ describe ULID do
 
     it 'is sortable' do
       ulid1, ulid2 = nil
-      Timecop.freeze do
-        ulid1 = ULID.generate
-        Timecop.travel Time.now + 1
-        ulid2 = ULID.generate
-      end
+      input_time = Time.now
+      ulid1 = ULID.generate(input_time)
+      ulid2 = ULID.generate(input_time + 1)
       assert ulid2 > ulid1
     end
 
@@ -30,22 +27,18 @@ describe ULID do
     it 'encodes the timestamp in the first 10 characters' do
       # test case taken from original ulid README:
       # https://github.com/alizain/ulid#seed-time
-      Timecop.freeze(Time.at(1_469_918_176.385)) do
-        ulid = ULID.generate(Time.at(1_469_918_176.385))
-        assert_equal '01ARYZ6S41', ulid[0...10]
-      end
+      ulid = ULID.generate(Time.at(1_469_918_176.385))
+      assert_equal '01ARYZ6S41', ulid[0...10]
     end
   end
 
   describe 'underlying binary' do
     it 'encodes the timestamp in the high 48 bits' do
       input_time = Time.now.utc
-      Timecop.freeze(input_time) do
-        bytes = ULID.generate_bytes
-        (time_ms,) = "\x0\x0#{bytes[0...6]}".unpack('Q>')
-        encoded_time = Time.at(time_ms / 1000.0).utc
-        assert_in_delta input_time, encoded_time, 0.001
-      end
+      bytes = ULID.generate_bytes(input_time)
+      (time_ms,) = "\x0\x0#{bytes[0...6]}".unpack('Q>')
+      encoded_time = Time.at(time_ms / 1000.0).utc
+      assert_in_delta input_time, encoded_time, 0.001
     end
 
     it 'encodes the remaining 80 bits as random' do


### PR DESCRIPTION
Instead, pass a `Time` instance when calling `ULID#generate` or `ULID#generate_bytes`.