### PR TITLE
Use an array to improve speed / reduce memory allocations

### DIFF
--- a/lib/ulid/generator.rb
+++ b/lib/ulid/generator.rb
@@ -1,3 +1,5 @@
+# frozen-string-literal: true
+
 if RUBY_VERSION >= '2.5'
   require 'securerandom'
 else
@@ -36,7 +38,7 @@ module ULID
         i -= 1
       end
 
-      e.pack('c*'.freeze)
+      e.pack('c*')
     end
 
     def octo_word(time = Time.now)

--- a/lib/ulid/generator.rb
+++ b/lib/ulid/generator.rb
@@ -6,7 +6,7 @@ end
 
 module ULID
   module Generator
-    ENCODING = '0123456789ABCDEFGHJKMNPQRSTVWXYZ'.freeze # Crockford's Base32
+    ENCODING = '0123456789ABCDEFGHJKMNPQRSTVWXYZ'.bytes.freeze # Crockford's Base32
     RANDOM_BYTES = 10
     ENCODED_LENGTH = 26
     BIT_LENGTH = 128
@@ -27,7 +27,7 @@ module ULID
     private
 
     def encode(input, length)
-      e = '0' * length
+      e = Array.new(length, 48) # '0'.ord
       i = length - 1
 
       while input > 0
@@ -36,7 +36,7 @@ module ULID
         i -= 1
       end
 
-      e
+      e.pack('c*'.freeze)
     end
 
     def octo_word(time = Time.now)

--- a/lib/ulid/generator.rb
+++ b/lib/ulid/generator.rb
@@ -13,6 +13,7 @@ module ULID
     ENCODED_LENGTH = 26
     BIT_LENGTH = 128
     BITS_PER_B32_CHAR = 5
+    ZERO = '0'.ord
 
     MASK = 0x1f
 
@@ -29,7 +30,7 @@ module ULID
     private
 
     def encode(input, length)
-      e = Array.new(length, 48) # '0'.ord
+      e = Array.new(length, ZERO)
       i = length - 1
 
       while input > 0


### PR DESCRIPTION
We can get a nice speed improvement by avoiding string manipulation in the base32 encoding step.

```
Calculating -------------------------------------
ULID.generate w/ Array
                         43.244k (± 3.6%) i/s -      1.081M in  25.035071s
ULID.generate w/ String
                         37.121k (± 2.8%) i/s -    927.744k in  25.013924s

Comparison:
ULID.generate w/ Array:    43244.3 i/s
ULID.generate w/ String:    37121.2 i/s - 1.16x  slower

Calculating -------------------------------------
ULID.generate w/ Array
                         1.942k memsize (     0.000  retained)
                        39.000  objects (     0.000  retained)
                         7.000  strings (     0.000  retained)

ULID.generate w/ String
                         2.697k memsize (     0.000  retained)
                        64.000  objects (     0.000  retained)
                        22.000  strings (     0.000  retained)

Comparison:
ULID.generate w/ Array:       1942 allocated
ULID.generate w/ String:       2697 allocated - 1.39x more
```
[Benchmark script - ips.rb](https://github.com/rafaelsales/ulid/files/4142535/ips.rb.txt)
