### PR TITLE
Ensure ULID order respects timestamp order to millisecond precision (#22)

### DIFF
--- a/lib/ulid/generator.rb
+++ b/lib/ulid/generator.rb
@@ -48,7 +48,7 @@ module ULID
     end
 
     def time_48bit(time = Time.now)
-      time_ms = (time.to_f * 1000).to_i
+      time_ms = (time.to_f * 1000).round
       [time_ms].pack('Q>')[2..-1]
     end
 

--- a/lib/ulid/generator.rb
+++ b/lib/ulid/generator.rb
@@ -57,9 +57,9 @@ module ULID
       #
       # vs
       #
-      # > time.to_i * 1000 + time.usec / 1000
+      # > (time.to_r * 1000).to_i
       # => 1578207780002
-      time_ms = time.to_i * 1000 + time.usec / 1000
+      time_ms = (time.to_r * 1000).to_i
       [time_ms].pack('Q>')[2..-1]
     end
 

--- a/lib/ulid/generator.rb
+++ b/lib/ulid/generator.rb
@@ -48,7 +48,18 @@ module ULID
     end
 
     def time_48bit(time = Time.now)
-      time_ms = (time.to_f * 1000).round
+      # Avoid `time.to_f` since we want to accurately represent a whole number of milliseconds:
+      #
+      # > time = Time.new(2020, 1, 5, 7, 3, Rational(2, 1000))
+      # => 2020-01-05 07:03:00 +0000
+      # > (time.to_f * 1000).to_i
+      # => 1578207780001
+      #
+      # vs
+      #
+      # > time.to_i * 1000 + time.usec / 1000
+      # => 1578207780002
+      time_ms = time.to_i * 1000 + time.usec / 1000
       [time_ms].pack('Q>')[2..-1]
     end
 

--- a/spec/lib/ulid_spec.rb
+++ b/spec/lib/ulid_spec.rb
@@ -26,7 +26,17 @@ describe ULID do
     it 'encodes the timestamp in the first 10 characters' do
       # test case taken from original ulid README:
       # https://github.com/alizain/ulid#seed-time
-      ulid = ULID.generate(Time.at(1_469_918_176.385))
+      #
+      # N.b. we avoid specifying the time as a float, since we lose precision:
+      #
+      # > Time.at(1_469_918_176.385).strftime("%F %T.%N")
+      # => "2016-07-30 23:36:16.384999990"
+      #
+      # vs the correct:
+      #
+      # > Time.at(1_469_918_176, 385, :millisecond).strftime("%F %T.%N")
+      # => "2016-07-30 23:36:16.385000000"
+      ulid = ULID.generate(Time.at(1_469_918_176, 385, :millisecond))
       assert_equal '01ARYZ6S41', ulid[0...10]
     end
 

--- a/spec/lib/ulid_spec.rb
+++ b/spec/lib/ulid_spec.rb
@@ -29,6 +29,16 @@ describe ULID do
       ulid = ULID.generate(Time.at(1_469_918_176.385))
       assert_equal '01ARYZ6S41', ulid[0...10]
     end
+
+    it 'respects millisecond-precision order' do
+      ulids = Array.new(1000) do |millis|
+        time = Time.new(2020, 1, 2, 3, 4, Rational(millis, 10**3))
+
+        ULID.generate(time)
+      end
+
+      assert_equal(ulids, ulids.sort)
+    end
   end
 
   describe 'underlying binary' do


### PR DESCRIPTION
This was coming from truncating using `to_i`:
```
> Time.new(2020, 1, 5, 7, 3, Rational(2, 1000)).to_f * 1000
=> 1578207780001.9998
> (Time.new(2020, 1, 5, 7, 3, Rational(2, 1000)).to_f * 1000).to_i
=> 1578207780001
```
