### PR TITLE
Refer updated github link of `alizain/ulid`

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,4 +113,4 @@ bundle exec rake test
 
 ### Credits and references:
 
-* https://github.com/alizain/ulid
+* https://github.com/ulid/javascript

--- a/spec/lib/ulid_spec.rb
+++ b/spec/lib/ulid_spec.rb
@@ -25,7 +25,7 @@ describe ULID do
 
     it 'encodes the timestamp in the first 10 characters' do
       # test case taken from original ulid README:
-      # https://github.com/alizain/ulid#seed-time
+      # https://github.com/ulid/javascript#seed-time
       ulid = ULID.generate(Time.at(1_469_918_176.385))
       assert_equal '01ARYZ6S41', ulid[0...10]
     end


### PR DESCRIPTION
Why
---

```
~/r/g/ulid ❯❯❯ curl https://github.com/alizain/ulid                                               update-origin-link
<html><body>You are being <a href="https://github.com/ulid/javascript">redirected</a>.</body></html>%
```

So looks changed the repository to https://github.com/ulid/javascript