### PR TITLE
CI: Use ruby/setup-ruby and bundler-cache

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -13,11 +13,10 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby
-      uses: actions/setup-ruby@v1
+      uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby-version }}
-    - name: Build and test with Rake
+        bundler-cache: true # Run "bundle install", and cache the result automatically.
+    - name: Run tests
       run: |
-        gem install bundler
-        bundle install --jobs 4 --retry 3
         bundle exec rake test

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ulid (1.2.0)
+    ulid (1.3.0)
 
 GEM
   remote: https://rubygems.org/
@@ -47,4 +47,4 @@ DEPENDENCIES
   ulid!
 
 BUNDLED WITH
-   2.0.1
+   2.2.25


### PR DESCRIPTION
This changes the Action used to the Ruby-maintained one, which has support for this installation and cache parameter.

This fixes the issue from #27 