### PR TITLE
gemspec: Drop directives test_files, executables

### DIFF
--- a/ulid.gemspec
+++ b/ulid.gemspec
@@ -12,8 +12,6 @@ Gem::Specification.new do |spec|
   spec.license       = 'MIT'
 
   spec.files         = `git ls-files -z`.split("\x0")
-  spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
-  spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
   spec.post_install_message = '


### PR DESCRIPTION
These are unused - the gem exposes no executables, and the test_files directive is not used on the RubyGems side.