### PR TITLE
Add support for decoding timestamp component from ULID string

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,22 @@ require 'ulid'
 ULID.generate # 01ARZ3NDEKTSV4RRFFQ69G5FAV
 ```
 
+You can optionally pass a `Time` instance to `generate` when generating a ULID to use for the timestamp prefix/component.
+
+```ruby
+time_t1 = Time.now
+ulid = ULID.generate(time_t1)
+```
+
+You can also decode the timestamp component of a ULID into a `Time` instance (to millisecond precision).
+
+```ruby
+time_t1 = Time.new(2022, 1, 4, 6, 3)
+ulid = ULID.generate(time_t1)
+time_t2 = ULID.decode_time(ulid)
+time_t2 == time_t1 # true
+```
+
 ## Specification
 
 Below is the current specification of ULID as implemented in this repository. *Note: the binary format has not been implemented.*

--- a/lib/ulid.rb
+++ b/lib/ulid.rb
@@ -1,6 +1,8 @@
 require 'ulid/version'
 require 'ulid/generator'
+require 'ulid/decoder'
 
 module ULID
   extend Generator
+  extend Decoder
 end

--- a/lib/ulid/decoder.rb
+++ b/lib/ulid/decoder.rb
@@ -1,0 +1,23 @@
+# frozen-string-literal: true
+
+require 'ulid/generator'
+
+module ULID
+  module Decoder
+    def decode_time(string)
+      if string.size != Generator::ENCODED_LENGTH
+        raise ArgumentError, 'string is not of ULID length'
+      end
+      epoch_time_ms = string.slice(0, 10).split('').reverse
+                            .each_with_index.reduce(0) do |carry, (char, index)|
+        encoding_index = Generator::ENCODING.index(char.bytes.first)
+        if encoding_index.nil?
+          raise ArgumentError, "invalid character found: #{char}"
+        end
+        carry += encoding_index * (Generator::ENCODING.size**index).to_i
+        carry
+      end
+      Time.at(epoch_time_ms / 1000, epoch_time_ms % 1000, :millisecond)
+    end
+  end
+end

--- a/spec/lib/ulid_spec.rb
+++ b/spec/lib/ulid_spec.rb
@@ -68,4 +68,31 @@ describe ULID do
       end
     end
   end
+
+  describe 'decoding a timestamp' do
+    it 'decodes the timestamp as Time' do
+      ulid = ULID.generate
+      assert ULID.decode_time(ulid).is_a?(Time)
+    end
+
+    it 'decodes the timestamp into milliseconds' do
+      input_time = Time.now.utc
+      ulid = ULID.generate(input_time)
+      output_time = ULID.decode_time(ulid).utc
+      assert_equal (input_time.to_f * 1000).to_i, (output_time.to_f * 1000).to_i
+    end
+
+    it 'rejects strings with invalid characters' do
+      assert_raises(ArgumentError) do
+        bad_ulid = ULID.generate.tr('0', '-')
+        ULID.decode_time(bad_ulid)
+      end
+    end
+
+    it 'rejects strings of incorrect length' do
+      assert_raises(ArgumentError) do
+        ULID.decode_time(ULID.generate + 'f')
+      end
+    end
+  end
 end


### PR DESCRIPTION
This adds a module for decoding the timestamp component out of a ULID
string into a `Time` instance. This is useful if you have a set of ULIDs
and want to do timeseries math based on their encoded data.