### PR TITLE
Allow for deterministic ULID generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,26 @@ require 'ulid'
 ULID.generate # 01ARZ3NDEKTSV4RRFFQ69G5FAV
 ```
 
+You can optionally pass a `Time` instance to `generate` when generating a ULID to use for the timestamp prefix/component.
+
+```ruby
+time_t1 = Time.now
+ulid = ULID.generate(time_t1)
+```
+
+You can optionally pass a hex-encodable `String` instance to `generate` as an event name for fully deterministic ULIDs. The `name` string will be encoded and used as the randomness suffix/component.
+
+```ruby
+require 'securerandom'
+
+time = Time.now
+event_name = SecureRandom.uuid
+ulid = ULID.generate(nil, event_name)
+ulid1 = ULID.generate(time, event_name)
+ulid2 = ULID.generate(time, event_name)
+ulid1 == ulid2 # true
+```
+
 ## Specification
 
 Below is the current specification of ULID as implemented in this repository. *Note: the binary format has not been implemented.*

--- a/lib/ulid/generator.rb
+++ b/lib/ulid/generator.rb
@@ -17,14 +17,15 @@ module ULID
 
     MASK = 0x1f
 
-    def generate(time = Time.now)
-      input = octo_word(time)
+    def generate(time = Time.now, name = nil)
+      input = octo_word(time, name)
 
       encode(input, ENCODED_LENGTH)
     end
 
-    def generate_bytes(time = Time.now)
-      time_48bit(time) + random_bytes
+    def generate_bytes(time = Time.now, name = nil)
+      name_bytes = name.split('').map { |e| e.to_i(32) }.pack('C*') if name
+      time_48bit(time) + (name_bytes || random_bytes)
     end
 
     private
@@ -42,8 +43,11 @@ module ULID
       e.pack('c*')
     end
 
-    def octo_word(time = Time.now)
-      (hi, lo) = generate_bytes(time).unpack('Q>Q>')
+    def octo_word(time = Time.now, name = nil)
+      (hi, lo) = generate_bytes(time, name).unpack('Q>Q>')
+      if hi.nil? || lo.nil?
+        raise ArgumentError, 'name string without hex encoding passed to ULID generator'
+      end
       (hi << 64) | lo
     end
 

--- a/spec/lib/ulid_spec.rb
+++ b/spec/lib/ulid_spec.rb
@@ -49,6 +49,39 @@ describe ULID do
 
       assert_equal(ulids, ulids.sort)
     end
+
+    it 'is deterministic based on time' do
+      input_time = Time.now
+      ulid1 = ULID.generate(input_time)
+      ulid2 = ULID.generate(input_time)
+      assert_equal ulid2.slice(0, 10), ulid1.slice(0, 10)
+      assert ulid2 != ulid1
+    end
+
+    it 'is deterministic based on event name' do
+      input_time = Time.now
+      input_event = SecureRandom.uuid
+      ulid1 = ULID.generate(input_time, input_event)
+      ulid2 = ULID.generate(input_time + 1, input_event)
+      assert_equal ulid2.slice(10, 26), ulid1.slice(10, 26)
+      assert ulid2 != ulid1
+    end
+
+    it 'is fully deterministic based on time and name' do
+      input_time = Time.now
+      input_event = SecureRandom.uuid
+      ulid1 = ULID.generate(input_time, input_event)
+      ulid2 = ULID.generate(input_time, input_event)
+      assert_equal ulid2, ulid1
+    end
+
+    it 'raises exception when non-encodable name string is used' do
+      input_time = Time.now
+      input_event = 'foobar'
+      assert_raises(ArgumentError) do
+        ULID.generate(input_time, input_event)
+      end
+    end
   end
 
   describe 'underlying binary' do


### PR DESCRIPTION
This changes the generator to accept a name/event string as a second
parameter to be encoded and used in place of the random bytes
suffix/component.

This is useful if you want to make deterministic ULIDs from an event source.