### PR TITLE
drop support for unsupported ruby versions

### DIFF
--- a/lib/ulid/generator.rb
+++ b/lib/ulid/generator.rb
@@ -1,10 +1,6 @@
 # frozen-string-literal: true
 
-if RUBY_VERSION >= '2.5'
-  require 'securerandom'
-else
-  require 'sysrandom/securerandom'
-end
+require 'securerandom'
 
 module ULID
   module Generator

--- a/lib/ulid/version.rb
+++ b/lib/ulid/version.rb
@@ -1,3 +1,4 @@
+# frozen-string-literal: true
 module ULID
-  VERSION = '1.3.0'.freeze
+  VERSION = '1.3.0'
 end

--- a/ulid.gemspec
+++ b/ulid.gemspec
@@ -1,6 +1,6 @@
 lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require 'ulid/version'
+require_relative 'lib/ulid/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'ulid'
@@ -13,9 +13,5 @@ Gem::Specification.new do |spec|
 
   spec.files         = `git ls-files -z`.split("\x0")
   spec.require_paths = ['lib']
-
-  spec.post_install_message = '
-ulid gem needs to install sysrandom gem if you use Ruby 2.4 or older.
-Execute `gem install sysrandom` or add `gem "sysrandom"` to Gemfile.
-'
+  spec.required_ruby_version = '>= 2.6.8'
 end


### PR DESCRIPTION
Hi @rafaelsales, long time :).

Ruby prior 2.7 reached EOL few years ago and [not really tested ](https://github.com/rafaelsales/ulid/blob/master/.github/workflows/ruby.yml#L11).

This PR will remove the support officially.