### PR TITLE
Run tests on Ruby 3.2

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['2.6', '2.7', '3.0', '3.1']
+        ruby-version: ['2.6', '2.7', '3.0', '3.1', '3.2']
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Adding test running for Ruby 3.2. Based implementation on https://github.com/rafaelsales/ulid/commit/df55ebe3baf4b4d022ca43e394fa6d4c2f9a5b14.

https://www.ruby-lang.org/en/news/2022/12/25/ruby-3-2-0-released/

Side note, can probably drop support for Ruby 2.6 (EOL) and 2.7 (EOL soon) if we like.

https://www.ruby-lang.org/en/downloads/branches/

Requires
- https://github.com/rafaelsales/ulid/pull/35