### PR TITLE
Add Support for Converting ULID Binary Data to String in Rails

### DIFF
--- a/spec/lib/ulid_spec.rb
+++ b/spec/lib/ulid_spec.rb
@@ -102,5 +102,37 @@ describe ULID do
         assert bytes[6..-1] == random_bytes
       end
     end
+
+    it 'converts a ULID string to binary and back' do
+      ulid = ULID.generate
+      binary = ULID.ulid_string_to_binary(ulid)
+      converted_ulid = ULID.binary_to_ulid_string(binary)
+      assert_equal ulid, converted_ulid
+    end
+
+    it 'raises an exception for invalid ULID string lengths' do
+      assert_raises(ArgumentError) do
+        ULID.ulid_string_to_binary('12345')
+      end
+    end
+
+    it 'raises an exception for invalid characters in ULID string' do
+      invalid_ulid = '0' * 25 + '!'
+      assert_raises(ArgumentError) do
+        ULID.ulid_string_to_binary(invalid_ulid)
+      end
+    end
+  end
+
+  describe 'conversion integrity' do
+    it 'maintains integrity through conversions' do
+      time = Time.now
+      suffix = SecureRandom.random_bytes(10) # 80 bits
+      original_ulid = ULID.generate(time, suffix: suffix.unpack1('H*'))
+      binary = ULID.ulid_string_to_binary(original_ulid)
+      regenerated_ulid = ULID.binary_to_ulid_string(binary)
+
+      assert_equal original_ulid, regenerated_ulid
+    end
   end
 end


### PR DESCRIPTION
## Description

This PR introduces new functionality to the ULID module, aimed at simplifying the interaction with ULID values stored as binary in MySQL databases when using Rails. Working directly with binary formats in Rails can be cumbersome, especially when dealing with model attributes. To address this, we've added methods to convert ULID values between binary and string representations seamlessly.

### Background

Our application utilizes ULIDs as a more sortable and time-precise alternative to UUIDs. These ULIDs are generated and stored in a MySQL database in their binary form to save space and ensure efficient querying. However, Rails' native handling of binary data requires verbose and repetitive conversion code, hindering developer productivity and increasing the risk of errors.

### Implementation

To address this issue, we've implemented a set of utility functions within the ULID module, specifically within the Generator submodule. These functions are designed to seamlessly integrate with Rails' ActiveRecord, allowing for the automatic conversion of binary ULID data to strings when records are loaded from the database, and vice versa when data is saved.

**Key Additions:**
`binary_to_ulid_string`: Converts binary ULID data to a string.
`ulid_string_to_binary`: Converts a ULID string back to binary format.

These methods extend the existing *ULID* module's functionality, making it more compatible with Rails applications and simplifying the handling of ULID identifiers.

## Usage Example

To leverage the new functionality, we recommend using a custom ActiveRecord type. This approach encapsulates the conversion logic, ensuring that ULID fields are automatically handled throughout the application.

Here's how to define a custom type for ULID:

```rb
# app/types/ulid_type.rb
class ULIDType < ActiveRecord::Type::Binary
  def cast(value)
    value
  end

  def deserialize(value)
    raw_value = super(value)
    return if raw_value.nil?

    ULID.binary_to_ulid_string(raw_value.to_s)
  end

  def serialize(value)
    return if value.nil?

    raw_value = ULID.string_to_ulid_byte(value)
    super(raw_value)
  end
end

# Register the new type for use with ActiveRecord
ActiveRecord::Type.register(:ulid, ULIDType)
```

With this custom type in place, you can now declare ULID attributes in your models like so:

```rb
class MyModel < ApplicationRecord
  attribute :ulid, :ulid
end
```

This setup ensures that ULID attributes are automatically converted to strings when accessed and converted back to binary when saved to the database, simplifying the use of ULID in a Rails context.

## Conclusion

By integrating these utility functions into the ULID module and leveraging ActiveRecord's custom types, we can significantly streamline the handling of ULID identifiers in Rails applications. This enhancement not only improves developer efficiency but also maintains the integrity and performance benefits of storing ULIDs in their binary form in the database.