### PR TITLE
Run tests on Ruby 3.3, 3,4

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['2.6', '2.7', '3.0', '3.1', '3.2', '3.3']
+        ruby-version: ['2.6', '2.7', '3.0', '3.1', '3.2', '3.3', '3.4']
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['2.6', '2.7', '3.0', '3.1', '3.2']
+        ruby-version: ['2.6', '2.7', '3.0', '3.1', '3.2', '3.3']
 
     steps:
     - uses: actions/checkout@v2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,7 +10,7 @@ GEM
     base32-crockford (0.1.0)
     byebug (11.1.3)
     json (2.6.3)
-    minitest (5.18.0)
+    minitest (5.25.4)
     parallel (1.22.1)
     parser (3.2.1.0)
       ast (~> 2.4.1)


### PR DESCRIPTION
Hi, this pull request just lets tests run on Ruby 3.3 and 3.4.

https://www.ruby-lang.org/en/news/2023/12/25/ruby-3-3-0-released/
https://www.ruby-lang.org/en/news/2024/12/25/ruby-3-4-1-released/

By the way, Ruby 3.0 or priors are already EOL.
I wonder if `required_ruby_version` could be more later version.

https://www.ruby-lang.org/en/downloads/branches/